### PR TITLE
fix: don't use ANSI chars in logs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,7 @@ async fn main() -> crate::error::Result<()> {
         tracing_subscriber::fmt()
             .with_max_level(state.config.log_level())
             .with_span_events(FmtSpan::CLOSE)
+            .with_ansi(false)
             .init();
     }
 


### PR DESCRIPTION
# Description

Only use ASCII chars in logs for better legibility in CloudWatch

## How Has This Been Tested?

Not Tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
