### PR TITLE
chore: rename `keyserver` to `keys-server` in strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# keyserver-rust
+# Keys-Server
 
 ## API Guide
 
@@ -16,13 +16,13 @@ Setup:
   ```
 - Fill `.env` file with necessary values
 
-Running the keyserver:
+Running the keys-server:
 ```sh
 $ source .env # make sure the env variables are set
 $ just run
 ```
 
-Running the docker-compose set up (MongoDB + MongoExpress + Jaeger + Keyserver):
+Running the docker-compose set up (MongoDB + MongoExpress + Jaeger + Keys-Server):
 ```sh
 $ source .env # make sure the env variables are set
 $ just build-docker

--- a/justfile
+++ b/justfile
@@ -44,20 +44,20 @@ fmt:
 
 # Build docker image
 build-docker:
-  @echo '=> Build keyserver docker image'
+  @echo '=> Build keys-server docker image'
   docker-compose -f ./ops/docker-compose.keyserver.yml -f ./ops/docker-compose.storage.yml build keyserver
 
-# Start keyserver & storage services on docker
+# Start keys-server & storage services on docker
 run-docker:
     @echo '==> Start services on docker'
     docker-compose -f ./ops/docker-compose.keyserver.yml -f ./ops/docker-compose.storage.yml up -d
 
-# Stop keyserver & storage services on docker
+# Stop keys-server & storage services on docker
 stop-docker:
   @echo '==> Stop services on docker'
   docker-compose -f ./ops/docker-compose.keyserver.yml -f ./ops/docker-compose.storage.yml down
 
-# Clean up docker keyserver & storage services
+# Clean up docker keys-server & storage services
 clean-docker:
   @echo '==> Clean services on docker'
   docker-compose  -f ./ops/docker-compose.keyserver.yml -f ./ops/docker-compose.storage.yml stop
@@ -79,9 +79,9 @@ clean-storage-docker:
   docker-compose -f ./ops/docker-compose.storage.yml stop
   docker-compose -f ./ops/docker-compose.storage.yml rm -f
 
-# Restart keyserver on docker
+# Restart keys-server on docker
 restart-keyserver-docker:
-  @echo '==> Restart keyserver service on docker'
+  @echo '==> Restart keys-server service on docker'
   docker-compose -f ./ops/docker-compose.keyserver.yml -f ./ops/docker-compose.storage.yml up -d --build --force-recreate --no-deps keyserver
 
 # Lint the project for any quality issues

--- a/src/error.rs
+++ b/src/error.rs
@@ -96,7 +96,7 @@ impl IntoResponse for Error {
                 StatusCode::INTERNAL_SERVER_ERROR,
                 ResponseError {
                     name: "unknown_error".to_string(),
-                    message: "This error should not have occurred. Please file an issue at: https://github.com/walletconnect/keyserver".to_string(),
+                    message: "This error should not have occurred. Please file an issue at: https://github.com/walletconnect/keys-server".to_string(),
                 }
             ),
         }.into_response()

--- a/terraform/ecs/network.tf
+++ b/terraform/ecs/network.tf
@@ -75,7 +75,7 @@ resource "aws_lb_target_group" "target_group" {
 
   health_check {
     protocol            = "HTTP"
-    path                = "/health" # KeyServer's health path
+    path                = "/health" # KeysServer's health path
     port                = var.port
     interval            = 15
     timeout             = 10

--- a/terraform/monitoring/dashboard.tf
+++ b/terraform/monitoring/dashboard.tf
@@ -2,7 +2,7 @@ data "jsonnet_file" "dashboard" {
   source = "${path.module}/dashboard.jsonnet"
 
   ext_str = {
-    dashboard_title = "keyserver - ${module.this.stage}"
+    dashboard_title = "Keys-Server - ${module.this.stage}"
     dashboard_uid   = "keyserver-${module.this.stage}"
 
     prometheus_uid = grafana_data_source.prometheus.uid

--- a/terraform/monitoring/panels/app/app_cpu_memory.libsonnet
+++ b/terraform/monitoring/panels/app/app_cpu_memory.libsonnet
@@ -14,8 +14,8 @@ local _configuration = defaults.configuration.timeseries_resource
   );
 
 local cpu_alert(vars) = alert.new(
-  name        = "%s Keyserver App CPU/Memory alert" % vars.environment,
-  message     = "%s Keyserver App CPU/Memory" % vars.environment,
+  name        = "%s Keys-Server App CPU/Memory alert" % vars.environment,
+  message     = "%s Keys-Server App CPU/Memory" % vars.environment,
   period      = '25m',
   frequency   = '1m',
   conditions  = [

--- a/terraform/monitoring/panels/docdb/available_memory.libsonnet
+++ b/terraform/monitoring/panels/docdb/available_memory.libsonnet
@@ -45,8 +45,8 @@ local _configuration = defaults.configuration.timeseries
 
 
 local mem_alert(vars) = alert.new(
-  name        = "%s Keyserver DocumentDB Freeable Memory Alert" % vars.environment,
-  message     = "%s Keyserver DocumentDB Freeable Memory" % vars.environment,
+  name        = "%s Keys-Server DocumentDB Freeable Memory Alert" % vars.environment,
+  message     = "%s Keys-Server DocumentDB Freeable Memory" % vars.environment,
   period      = '5m',
   frequency   = '1m',
   notifications = vars.notifications,

--- a/terraform/monitoring/panels/docdb/cpu.libsonnet
+++ b/terraform/monitoring/panels/docdb/cpu.libsonnet
@@ -15,8 +15,8 @@ local _configuration = defaults.configuration.timeseries_resource
 
 
 local cpu_alert(vars) = alert.new(
-  name        = "%s Keyserver DocumentDB CPU alert" % vars.environment,
-  message     = "%s Keyserver DocumentDB CPU alert" % vars.environment,
+  name        = "%s Keys-Server DocumentDB CPU alert" % vars.environment,
+  message     = "%s Keys-Server DocumentDB CPU alert" % vars.environment,
   period      = '5m',
   frequency   = '1m',
   notifications = vars.notifications,

--- a/terraform/monitoring/panels/docdb/low_mem_op_throttled.libsonnet
+++ b/terraform/monitoring/panels/docdb/low_mem_op_throttled.libsonnet
@@ -31,8 +31,8 @@ local _configuration  = defaults.configuration.timeseries
 
 
 local ops_alert(vars) = alert.new(
-  name        = "%s Keyserver DocumentDB LowMem Num Operations Throttled Alert" % vars.environment,
-  message     = "%s Keyserver DocumentDB LowMem Num Operations Throttled" % vars.environment,
+  name        = "%s Keys-Server DocumentDB LowMem Num Operations Throttled Alert" % vars.environment,
+  message     = "%s Keys-Server DocumentDB LowMem Num Operations Throttled" % vars.environment,
   period      = '5m',
   frequency   = '1m',
   notifications = vars.notifications,


### PR DESCRIPTION
# Description

Rename `keyserver` to `keys-server` in human-readable strings.
Resource strings are kept untouched since that would force us to redeploy the whole infra.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
