### PR TITLE
fix: remove `rate` from Prometheus queries

### DIFF
--- a/terraform/monitoring/panels/app/identity/invalid_register_cacao.libsonnet
+++ b/terraform/monitoring/panels/app/identity/invalid_register_cacao.libsonnet
@@ -13,9 +13,10 @@ local defaults  = import '../../defaults.libsonnet';
     .configure(defaults.configuration.timeseries)
 
     .addTarget(targets.prometheus(
-      datasource  = ds.prometheus,
-      expr        = 'sum(rate(invalid_identity_register_cacao{aws_ecs_task_family="%s"}[5m]))' % vars.ecs_task_family,
-      refId       = "sources",
-      exemplar    = true,
+      legendFormat  = 'Invalid CACAOs',
+      datasource    = ds.prometheus,
+      expr          = 'sum(invalid_identity_register_cacao{aws_ecs_task_family="%s"})' % vars.ecs_task_family,
+      refId         = "sources",
+      exemplar      = true,
     ))
 }

--- a/terraform/monitoring/panels/app/identity/invalid_unregister_jwt.libsonnet
+++ b/terraform/monitoring/panels/app/identity/invalid_unregister_jwt.libsonnet
@@ -13,9 +13,10 @@ local defaults  = import '../../defaults.libsonnet';
     .configure(defaults.configuration.timeseries)
 
     .addTarget(targets.prometheus(
-      datasource  = ds.prometheus,
-      expr        = 'sum(rate(invalid_identity_unregister_jwt{aws_ecs_task_family="%s"}[5m]))' % vars.ecs_task_family,
-      refId       = "sources",
-      exemplar    = true,
+      legendFormat  = 'Invalid JWTs',
+      datasource    = ds.prometheus,
+      expr          = 'sum(invalid_identity_unregister_jwt{aws_ecs_task_family="%s"})' % vars.ecs_task_family,
+      refId         = "sources",
+      exemplar      = true,
     ))
 }

--- a/terraform/monitoring/panels/app/identity/register.libsonnet
+++ b/terraform/monitoring/panels/app/identity/register.libsonnet
@@ -13,9 +13,10 @@ local defaults  = import '../../defaults.libsonnet';
     .configure(defaults.configuration.timeseries)
 
     .addTarget(targets.prometheus(
-      datasource  = ds.prometheus,
-      expr        = 'sum(rate(identity_register{aws_ecs_task_family="%s"}[5m]))' % vars.ecs_task_family,
-      refId       = "sources",
-      exemplar    = true,
+      legendFormat  = 'Registrations',
+      datasource    = ds.prometheus,
+      expr          = 'sum(identity_register{aws_ecs_task_family="%s"})' % vars.ecs_task_family,
+      refId         = "sources",
+      exemplar      = true,
     ))
 }

--- a/terraform/monitoring/panels/app/identity/resolved.libsonnet
+++ b/terraform/monitoring/panels/app/identity/resolved.libsonnet
@@ -13,9 +13,10 @@ local defaults  = import '../../defaults.libsonnet';
     .configure(defaults.configuration.timeseries)
 
     .addTarget(targets.prometheus(
-      datasource  = ds.prometheus,
-      expr        = 'sum(rate(identity_resolved{aws_ecs_task_family="%s"}[5m]))' % vars.ecs_task_family,
-      refId       = "sources",
-      exemplar    = true,
+      legendFormat  = 'Resolutions',
+      datasource    = ds.prometheus,
+      expr          = 'sum(identity_resolved{aws_ecs_task_family="%s"})' % vars.ecs_task_family,
+      refId         = "sources",
+      exemplar      = true,
     ))
 }

--- a/terraform/monitoring/panels/app/identity/unregister.libsonnet
+++ b/terraform/monitoring/panels/app/identity/unregister.libsonnet
@@ -13,9 +13,10 @@ local defaults  = import '../../defaults.libsonnet';
     .configure(defaults.configuration.timeseries)
 
     .addTarget(targets.prometheus(
-      datasource  = ds.prometheus,
-      expr        = 'sum(rate(identity_unregister{aws_ecs_task_family="%s"}[5m]))' % vars.ecs_task_family,
-      refId       = "sources",
-      exemplar    = true,
+      legendFormat  = 'Unregistrations',
+      datasource    = ds.prometheus,
+      expr          = 'sum(identity_unregister{aws_ecs_task_family="%s"})' % vars.ecs_task_family,
+      refId         = "sources",
+      exemplar      = true,
     ))
 }

--- a/terraform/monitoring/panels/app/invite/invalid_register_jwt.libsonnet
+++ b/terraform/monitoring/panels/app/invite/invalid_register_jwt.libsonnet
@@ -13,9 +13,10 @@ local defaults  = import '../../defaults.libsonnet';
     .configure(defaults.configuration.timeseries)
 
     .addTarget(targets.prometheus(
-      datasource  = ds.prometheus,
-      expr        = 'sum(rate(invalid_invite_register_jwt{aws_ecs_task_family="%s"}[5m]))' % vars.ecs_task_family,
-      refId       = "sources",
-      exemplar    = true,
+      legendFormat  = 'Invalid JWTs',
+      datasource    = ds.prometheus,
+      expr          = 'sum(invalid_invite_register_jwt{aws_ecs_task_family="%s"})' % vars.ecs_task_family,
+      refId         = "sources",
+      exemplar      = true,
     ))
 }

--- a/terraform/monitoring/panels/app/invite/invalid_unregister_jwt.libsonnet
+++ b/terraform/monitoring/panels/app/invite/invalid_unregister_jwt.libsonnet
@@ -13,9 +13,10 @@ local defaults  = import '../../defaults.libsonnet';
     .configure(defaults.configuration.timeseries)
 
     .addTarget(targets.prometheus(
-      datasource  = ds.prometheus,
-      expr        = 'sum(rate(invalid_invite_unregister_jwt{aws_ecs_task_family="%s"}[5m]))' % vars.ecs_task_family,
-      refId       = "sources",
-      exemplar    = true,
+      legendFormat  = 'Invalid JWTs',
+      datasource    = ds.prometheus,
+      expr          = 'sum(invalid_invite_unregister_jwt{aws_ecs_task_family="%s"})' % vars.ecs_task_family,
+      refId         = "sources",
+      exemplar      = true,
     ))
 }

--- a/terraform/monitoring/panels/app/invite/register.libsonnet
+++ b/terraform/monitoring/panels/app/invite/register.libsonnet
@@ -13,9 +13,10 @@ local defaults  = import '../../defaults.libsonnet';
     .configure(defaults.configuration.timeseries)
 
     .addTarget(targets.prometheus(
-      datasource  = ds.prometheus,
-      expr        = 'sum(rate(invite_register{aws_ecs_task_family="%s"}[5m]))' % vars.ecs_task_family,
-      refId       = "sources",
-      exemplar    = true,
+      legendFormat  = 'Registrations',
+      datasource    = ds.prometheus,
+      expr          = 'sum(invite_register{aws_ecs_task_family="%s"})' % vars.ecs_task_family,
+      refId         = "sources",
+      exemplar      = true,
     ))
 }

--- a/terraform/monitoring/panels/app/invite/resolved.libsonnet
+++ b/terraform/monitoring/panels/app/invite/resolved.libsonnet
@@ -13,9 +13,10 @@ local defaults  = import '../../defaults.libsonnet';
     .configure(defaults.configuration.timeseries)
 
     .addTarget(targets.prometheus(
-      datasource  = ds.prometheus,
-      expr        = 'sum(rate(invite_resolved{aws_ecs_task_family="%s"}[5m]))' % vars.ecs_task_family,
-      refId       = "sources",
-      exemplar    = true,
+      legendFormat  = 'Resolutions',
+      datasource    = ds.prometheus,
+      expr          = 'sum(invite_resolved{aws_ecs_task_family="%s"})' % vars.ecs_task_family,
+      refId         = "sources",
+      exemplar      = true,
     ))
 }

--- a/terraform/monitoring/panels/app/invite/unregister.libsonnet
+++ b/terraform/monitoring/panels/app/invite/unregister.libsonnet
@@ -13,9 +13,10 @@ local defaults  = import '../../defaults.libsonnet';
     .configure(defaults.configuration.timeseries)
 
     .addTarget(targets.prometheus(
-      datasource  = ds.prometheus,
-      expr        = 'sum(rate(invite_unregister{aws_ecs_task_family="%s"}[5m]))' % vars.ecs_task_family,
-      refId       = "sources",
-      exemplar    = true,
+      legendFormat  = 'Unregistrations',
+      datasource    = ds.prometheus,
+      expr          = 'sum(invite_unregister{aws_ecs_task_family="%s"})' % vars.ecs_task_family,
+      refId         = "sources",
+      exemplar      = true,
     ))
 }


### PR DESCRIPTION
# Description

Remove the `rate` function from the Prometheus queries to only show raw numbers

## How Has This Been Tested?

Deployed to `staging`

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
