### PR TITLE
chore: display actual version passed to the CD

### DIFF
--- a/.github/workflows/event_release.yaml
+++ b/.github/workflows/event_release.yaml
@@ -72,7 +72,7 @@ jobs:
       version: ${{ steps.release.outputs.version }}
 
   released_version:
-    name: Version ➠ ${{ needs.update_version.outputs.version }}
+    name: Release Version ➠ ${{ needs.update_version.outputs.version }}
     runs-on:
       group: ${{ vars.RUN_GROUP }}
     needs: [ update_version ]
@@ -122,6 +122,14 @@ jobs:
           fi
     outputs:
       version: ${{ steps.get_target_version.outputs.version }}
+
+  used_version:
+    name: Version ➠ ${{ needs.get_version.outputs.version }}
+    runs-on:
+      group: ${{ vars.RUN_GROUP }}
+    needs: [ get_version ]
+    steps:
+      - run: echo "Version = ${{ needs.get_version.outputs.version }}
 
   cd:
     name: CD


### PR DESCRIPTION
# Description

Add a task to display the version output from the `get-version` task in the release event handler

Resolves #132 

## How Has This Been Tested?

N/A

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
