### PR TITLE
fix: use local version of geoip db

### DIFF
--- a/terraform/ecs/cluster_iam.tf
+++ b/terraform/ecs/cluster_iam.tf
@@ -16,6 +16,36 @@ data "aws_iam_policy_document" "ecs_task_assume_role_policy" {
   }
 }
 
+# GeoIP Bucket Access
+resource "aws_iam_policy" "geoip_bucket_access" {
+  name        = "${module.this.id}-geoip-bucket_access"
+  path        = "/"
+  description = "Allows ${module.this.id} to read from ${var.geoip_db_bucket_name}"
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "ListObjectsInGeoipBucket",
+        "Effect" : "Allow",
+        "Action" : ["s3:ListBucket"],
+        "Resource" : ["arn:aws:s3:::${var.geoip_db_bucket_name}"]
+      },
+      {
+        "Sid" : "AllObjectActionsInGeoipBucket",
+        "Effect" : "Allow",
+        "Action" : ["s3:CopyObject", "s3:GetObject", "s3:HeadObject"],
+        "Resource" : ["arn:aws:s3:::${var.geoip_db_bucket_name}/*"]
+      },
+    ]
+  })
+}
+resource "aws_iam_role_policy_attachment" "geoip_bucket_access" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = aws_iam_policy.geoip_bucket_access.arn
+}
+
+
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
   role       = aws_iam_role.ecs_task_execution_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"

--- a/terraform/inputs.tf
+++ b/terraform/inputs.tf
@@ -8,15 +8,15 @@ data "terraform_remote_state" "org" {
   }
 }
 
-data "terraform_remote_state" "datalake" {
-  backend = "remote"
-  config = {
-    organization = "wallet-connect"
-    workspaces = {
-      name = "data-lake-${module.this.stage}"
-    }
-  }
-}
+#data "terraform_remote_state" "datalake" {
+#  backend = "remote"
+#  config = {
+#    organization = "wallet-connect"
+#    workspaces = {
+#      name = "data-lake-${module.this.stage}"
+#    }
+#  }
+#}
 
 data "terraform_remote_state" "dns" {
   backend = "remote"

--- a/terraform/res_application.tf
+++ b/terraform/res_application.tf
@@ -1,3 +1,7 @@
+data "aws_s3_bucket" "geoip" {
+  bucket = "keyserver.${module.this.stage}.geoip.database.private.walletconnect"
+}
+
 # ECS Cluster, Task, Service, and Load Balancer for our app
 module "ecs" {
   source  = "./ecs"
@@ -31,6 +35,6 @@ module "ecs" {
   prometheus_endpoint = aws_prometheus_workspace.prometheus.prometheus_endpoint
 
   # GeoIP
-  geoip_db_bucket_name = data.terraform_remote_state.datalake.outputs.geoip_bucket_id
+  geoip_db_bucket_name = data.aws_s3_bucket.geoip.id
   geoip_db_key         = var.geoip_db_key
 }


### PR DESCRIPTION
# Description

Use a local version of the GeoIP DB until a central one with the right permissions is deployed.

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
