### PR TITLE
ci: bump update_rust_version to 2.1.5

### DIFF
--- a/.github/workflows/dispatch_publish.yaml
+++ b/.github/workflows/dispatch_publish.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Release
         id: release
-        uses: WalletConnect/actions/github/update-rust-version/@2.1.4
+        uses: WalletConnect/actions/github/update-rust-version/@2.1.5
         with:
           token: ${{ secrets.RELEASE_PAT }}
     outputs:

--- a/.github/workflows/event_release.yaml
+++ b/.github/workflows/event_release.yaml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Release
         id: release
-        uses: WalletConnect/actions/github/update-rust-version/@2.1.4
+        uses: WalletConnect/actions/github/update-rust-version/@2.1.5
         with:
           token: ${{ secrets.RELEASE_PAT }}
     outputs:


### PR DESCRIPTION
# Description

Bumping `update-rust-version` CI action script to 2.1.5 [because of Cargo.lock issue](https://github.com/WalletConnect/actions/issues/20).

Resolves #149

## How Has This Been Tested?

Test plan in https://github.com/WalletConnect/actions/issues/20

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
