### PR TITLE
fix: add cors on delete

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub async fn bootstrap(
     let cors_layer = CorsLayer::new()
         .allow_headers([http::header::CONTENT_TYPE])
         .allow_origin("*".parse::<HeaderValue>().unwrap())
-        .allow_methods([Method::GET, Method::POST]);
+        .allow_methods([Method::GET, Method::POST, Method::DELETE]);
 
     let app = Router::new()
         .route("/health", get(handlers::health::handler))


### PR DESCRIPTION
# Description

* Add `Method:DELETE` to cors layer to allow unregistering/deleting identity keys

Resolves #151 

## Due Diligence

* [x] Breaking change
* [x] Requires a documentation update
* [x] Requires a e2e/integration test update
