### PR TITLE
fix: add timing traces

### DIFF
--- a/justfile
+++ b/justfile
@@ -42,6 +42,17 @@ fmt:
   @echo '==> Reformatting code'
   cargo +nightly fmt
 
+fmt-imports:
+  #!/bin/bash
+  set -euo pipefail
+
+  if command -v cargo-fmt >/dev/null; then
+    echo '==> Running rustfmt'
+    cargo +nightly fmt -- --config group_imports=StdExternalCrate,imports_granularity=One
+  else
+    echo '==> rustfmt not found in PATH, skipping'
+  fi
+
 # Build docker image
 build-docker:
   @echo '=> Build keys-server docker image'

--- a/src/stores/keys.rs
+++ b/src/stores/keys.rs
@@ -208,12 +208,15 @@ impl KeysPersistentStorage for MongoPersistentStorage {
     }
 
     async fn get_cacao_by_identity_key(&self, identity_key: &str) -> Result<Cacao, StoreError> {
+        info!("get_cacao_by_identity_key");
         let filter = doc! {
             "identities.identity_key": identity_key,
         };
 
+        info!("constructing not_found");
         let not_found = StoreError::NotFound("Identity key".to_string(), identity_key.to_string());
 
+        info!("find_one");
         match MongoKeys::find_one(&self.db, Some(filter), None).await? {
             Some(mongo_keys) => {
                 info!(
@@ -223,11 +226,14 @@ impl KeysPersistentStorage for MongoPersistentStorage {
                     mongo_keys
                 );
 
+                info!("Timing - find - Start");
                 let mongo_identity = mongo_keys
                     .identities
                     .into_iter()
                     .find(|i| i.identity_key == *identity_key)
                     .ok_or(not_found)?;
+                info!("Timing - find - End");
+
                 Ok(mongo_identity.cacao)
             }
             None => Err(not_found),


### PR DESCRIPTION
# Description

- Implement timing traces to see what's slowing down requests.
- Refactor to avoid redundant `ResolveIdentityParams` struct.
- Add `fmt-imports` target to keep code formatting

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
