### PR TITLE
fix: add x request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,9 +3399,11 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ axum = "0.6.1"
 axum-macros = "0.3.0"
 tokio = { version = "1.0", features = ["full"] }
 tower = { version = "0.4", features = ["util", "timeout", "load-shed", "limit"] }
-tower-http = { version = "0.3.0", features = ["add-extension", "auth", "compression-full", "trace", "cors"] }
+tower-http = { version = "0.3.0", features = ["add-extension", "auth", "compression-full", "trace", "cors", "request-id", "util"] }
 hyper = "0.14"
 http = "0.2.8"
 

--- a/justfile
+++ b/justfile
@@ -42,6 +42,17 @@ fmt:
   @echo '==> Reformatting code'
   cargo +nightly fmt
 
+fmt-imports:
+  #!/bin/bash
+  set -euo pipefail
+
+  if command -v cargo-fmt >/dev/null; then
+    echo '==> Running rustfmt'
+    cargo +nightly fmt -- --config group_imports=StdExternalCrate,imports_granularity=One
+  else
+    echo '==> rustfmt not found in PATH, skipping'
+  fi
+
 # Build docker image
 build-docker:
   @echo '=> Build keys-server docker image'

--- a/justfile
+++ b/justfile
@@ -37,11 +37,6 @@ clean:
   @echo '==> Cleaning project target/*'
   cargo clean
 
-# Reformat code
-fmt:
-  @echo '==> Reformatting code'
-  cargo +nightly fmt
-
 fmt-imports:
   #!/bin/bash
   set -euo pipefail
@@ -96,7 +91,11 @@ restart-keyserver-docker:
   docker-compose -f ./ops/docker-compose.keyserver.yml -f ./ops/docker-compose.storage.yml up -d --build --force-recreate --no-deps keyserver
 
 # Lint the project for any quality issues
-lint: rs-check-fmt check clippy commit-check
+lint: clippy fmt commit-check
+
+unit: lint test test-all test-doc tf-lint
+
+devloop: unit fmt-imports
 
 # Run project linter
 clippy:
@@ -111,13 +110,13 @@ clippy:
   fi
 
 # Run code formatting check
-rs-check-fmt:
+fmt:
   #!/bin/bash
   set -euo pipefail
 
   if command -v cargo-fmt >/dev/null; then
     echo '==> Running rustfmt'
-    cargo fmt -- --check
+    cargo fmt
   else
     echo '==> rustfmt not found in PATH, skipping'
   fi

--- a/src/handlers/identity/resolve.rs
+++ b/src/handlers/identity/resolve.rs
@@ -35,7 +35,7 @@ impl From<ResolveIdentityResponse> for Value {
     }
 }
 
-#[instrument(name = "resolve_handler", skip(state))]
+#[instrument(name = "resolve_handler", skip_all)]
 pub async fn handler(
     State(state): State<Arc<AppState>>,
     Query(params): Query<ResolveIdentityPayload>,

--- a/src/stores/keys.rs
+++ b/src/stores/keys.rs
@@ -208,12 +208,15 @@ impl KeysPersistentStorage for MongoPersistentStorage {
     }
 
     async fn get_cacao_by_identity_key(&self, identity_key: &str) -> Result<Cacao, StoreError> {
+        info!("get_cacao_by_identity_key");
         let filter = doc! {
             "identities.identity_key": identity_key,
         };
 
+        info!("constructing not_found");
         let not_found = StoreError::NotFound("Identity key".to_string(), identity_key.to_string());
 
+        info!("find_one");
         match MongoKeys::find_one(&self.db, Some(filter), None).await? {
             Some(mongo_keys) => {
                 info!(
@@ -223,11 +226,14 @@ impl KeysPersistentStorage for MongoPersistentStorage {
                     mongo_keys
                 );
 
+                info!("Timing - find - Start");
                 let mongo_identity = mongo_keys
                     .identities
                     .into_iter()
                     .find(|i| i.identity_key == *identity_key)
                     .ok_or(not_found)?;
+                info!("Timing - find - End");
+
                 Ok(mongo_identity.cacao)
             }
             None => Err(not_found),


### PR DESCRIPTION
# Description

#160 didn't have a unique per-request ID, this adds a span specifically for that.

Also supports the x-request-id ID for better tracing.

Also adds `just devloop` pipeline which adapts closer to Notify Server pipeline including running unit tests and `fmt-imports`

## How Has This Been Tested?

Not tested, but copied from https://github.com/WalletConnect/blockchain-api/commit/ab0a84a1a2a14230f189549fb3cfe1df9dbaec26

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
