### PR TITLE
fix(ci): using the `latest` and `manual` image tag in the manual deploy

### DIFF
--- a/.github/workflows/dispatch_deploy.yaml
+++ b/.github/workflows/dispatch_deploy.yaml
@@ -1,5 +1,5 @@
 name: ⚙️ Deploy
-run-name: "Deploy: ${{ github.sha }} ➠ ${{ inputs.version }}${{ (!inputs.deploy-infra && !inputs.deploy-app) && ' 👀 deploy nothing' || ''}}${{ inputs.deploy-infra && ' ❱❱  infra' || '' }}${{ inputs.deploy-app && ' ❱❱  app' || '' }}"
+run-name: "Deploy: ${{ github.sha }} ➠ ${{ inputs.version-type }}:${{ inputs.version-tag }}${{ (!inputs.deploy-infra && !inputs.deploy-app) && ' 👀 deploy nothing' || ''}}${{ inputs.deploy-infra && ' ❱❱  infra' || '' }}${{ inputs.deploy-app && ' ❱❱  app' || '' }}"
 
 on:
   workflow_dispatch:
@@ -22,11 +22,18 @@ on:
           - prod
         default: staging
         required: true
-      version:
+      version-type:
         description: "Release Version"
-        type: string
-        required: true
+        type: choice
+        options:
+          - latest
+          - manual
         default: 'latest'
+        required: true
+      version-tag:
+        description: "Release Version Tag (for manual version)"
+        type: string
+        default: ''
 
 concurrency: deploy
 
@@ -51,10 +58,10 @@ jobs:
       - name: Select target version
         id: select_version
         run: |
-          if [ "${{ inputs.version }}" == "latest" ]; then
+          if [ "${{ inputs.version-type }}" == "latest" ]; then
             echo "version=$(git tag | sort --version-sort | tail -n1)" >> "$GITHUB_OUTPUT"
           else
-            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "version=${{ inputs.version-tag }}" >> "$GITHUB_OUTPUT"
           fi
     outputs:
       version: ${{ steps.select_version.outputs.version }}

--- a/.github/workflows/dispatch_deploy.yaml
+++ b/.github/workflows/dispatch_deploy.yaml
@@ -26,6 +26,7 @@ on:
         description: "Release Version"
         type: string
         required: true
+        default: 'latest'
 
 concurrency: deploy
 
@@ -35,13 +36,37 @@ permissions:
   packages: write
 
 jobs:
+
+  select_version:
+    name: Select Version
+    if: ${{ always() && !cancelled() && !failure() }}
+    runs-on:
+      group: ${{ vars.RUN_GROUP }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Select target version
+        id: select_version
+        run: |
+          if [ "${{ inputs.version }}" == "latest" ]; then
+            echo "version=$(git tag | sort --version-sort | tail -n1)" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          fi
+    outputs:
+      version: ${{ steps.select_version.outputs.version }}
+
   cd:
     name: CD
+    needs: [ select_version ]
     uses: ./.github/workflows/sub-cd.yml
     secrets: inherit
     with:
       deploy-infra: ${{ inputs.deploy-infra }}
       deploy-app: ${{ inputs.deploy-app }}
       deploy-prod: ${{ inputs.stage == 'prod' }}
-      version: ${{ inputs.version }}
+      version: ${{ needs.select_version.outputs.version }}
       skip_window: true


### PR DESCRIPTION
# Description

This PR fixes the error on the manual dispatch of the [`Deploy` workflow](https://github.com/WalletConnect/keys-server/actions/workflows/dispatch_deploy.yaml) with the default empty image tag by making the following changes:
* Making the `Release Version` as an option with the following options:
  * `latest` - latest release tag.
  * `manual` - manual image tag version to deploy.
    * Using the manual tag only when the `manual` option is chosen.

## How Has This Been Tested?

Tested by invoking the workflow from the branch.

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
