### PR TITLE
fix: invalid tag on latest version deploy

### DIFF
--- a/.github/workflows/dispatch_deploy.yaml
+++ b/.github/workflows/dispatch_deploy.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 15
           fetch-tags: true
       - name: Select target version
         id: select_version


### PR DESCRIPTION
# Description

I think same issue as https://github.com/WalletConnect/notify-server/pull/323. Cannot use `latest` in manual deploy:

```
CannotPullContainerError: pull image manifest has been retried 1 time(s): failed to resolve ref 139235753791.dkr.ecr.eu-central-1.amazonaws.com/keyserver:v1.0.1: 139235753791.dkr.ecr.eu-central-1.amazonaws.com/keyserver:v1.0.1: not found
```

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
