### PR TITLE
fix: query performance on DocumentDB

### DIFF
--- a/src/stores/keys.rs
+++ b/src/stores/keys.rs
@@ -211,6 +211,10 @@ impl KeysPersistentStorage for MongoPersistentStorage {
         info!("get_cacao_by_identity_key");
         let filter = doc! {
             "identities.identity_key": identity_key,
+            "identities.identity_key": {
+                "$exists": true, // https://docs.aws.amazon.com/documentdb/latest/developerguide/functional-differences.html#functional-differences.sparse-index
+                "$eq": identity_key,
+            },
         };
 
         info!("constructing not_found");

--- a/src/stores/keys.rs
+++ b/src/stores/keys.rs
@@ -210,7 +210,6 @@ impl KeysPersistentStorage for MongoPersistentStorage {
     async fn get_cacao_by_identity_key(&self, identity_key: &str) -> Result<Cacao, StoreError> {
         info!("get_cacao_by_identity_key");
         let filter = doc! {
-            "identities.identity_key": identity_key,
             "identities.identity_key": {
                 "$exists": true, // https://docs.aws.amazon.com/documentdb/latest/developerguide/functional-differences.html#functional-differences.sparse-index
                 "$eq": identity_key,


### PR DESCRIPTION
# Description

Resolves the use of COLSCAN instead of IXSCAN.

With DocumentDB on a sparse index, you must use `$exists: true` in the query or else it will always use a COLSCAN: https://docs.aws.amazon.com/documentdb/latest/developerguide/functional-differences.html#functional-differences.sparse-index

[Slack conversation](https://walletconnect.slack.com/archives/C068RRL89HC/p1707334769713159)
[Slack conversation](https://walletconnect.slack.com/archives/C044SKFKELR/p1707335021051799)

## How Has This Been Tested?

Manually

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
