### PR TITLE
fix: downscale ECS, staging env

### DIFF
--- a/.github/workflows/dispatch_deploy.yaml
+++ b/.github/workflows/dispatch_deploy.yaml
@@ -47,8 +47,7 @@ jobs:
   select_version:
     name: Select Version
     if: ${{ always() && !cancelled() && !failure() }}
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/dispatch_publish.yaml
+++ b/.github/workflows/dispatch_publish.yaml
@@ -32,8 +32,7 @@ jobs:
 
   update_version:
     name: Update Version
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     needs: [ci]
     steps:
       - name: Checkout
@@ -53,8 +52,7 @@ jobs:
 
   released_version:
     name: Version ➠ ${{ needs.update_version.outputs.version }}
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     needs: [ update_version ]
     steps:
       - run: echo "Version = ${{ needs.update_version.outputs.version }}"

--- a/.github/workflows/event_intake.yml
+++ b/.github/workflows/event_intake.yml
@@ -24,8 +24,7 @@ jobs:
   auto-promote:
     name: auto-promote
     if: github.event.action == 'opened'
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     steps:
       - name: Check Core Team membership
         uses: tspascoal/get-user-teams-membership@v1

--- a/.github/workflows/event_pr.yaml
+++ b/.github/workflows/event_pr.yaml
@@ -26,8 +26,7 @@ permissions:
 jobs:
   check_pr:
     name: Check PR
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     permissions:
       statuses: write
     steps:
@@ -38,8 +37,7 @@ jobs:
 
   paths_filter:
     name: Paths Filter
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
@@ -65,8 +63,7 @@ jobs:
 
   merge_check:
     name: Merge Check
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     if: ${{ always() && !cancelled() && !failure() }}
     needs: [check_pr, ci]
     steps:

--- a/.github/workflows/event_release.yaml
+++ b/.github/workflows/event_release.yaml
@@ -33,8 +33,7 @@ jobs:
 
   paths_filter:
     name: Paths Filter
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
@@ -51,8 +50,7 @@ jobs:
 
   update_version:
     name: Update Version
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     if: ${{ needs.paths_filter.outputs.app == 'true' }}
     needs: [paths_filter]
     steps:
@@ -73,8 +71,7 @@ jobs:
 
   released_version:
     name: Release Version ➠ ${{ needs.update_version.outputs.version }}
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubutnu-latest
     needs: [ update_version ]
     steps:
       - run: echo "Version = ${{ needs.update_version.outputs.version }}"
@@ -97,8 +94,7 @@ jobs:
 
   get_version:
     name: Get Version
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     needs: [ paths_filter, update_version, publish_image-staging, publish_image-prod ]
     if: ${{ always() && !cancelled() && !failure() }}
     steps:
@@ -126,8 +122,7 @@ jobs:
   used_version:
     name: Version ➠ ${{ needs.get_version.outputs.version }}
     if: ${{ always() && !cancelled() && !failure() }}
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     needs: [ get_version ]
     steps:
       - run: echo "Version = ${{ needs.get_version.outputs.version }}"

--- a/.github/workflows/sub-app-check.yml
+++ b/.github/workflows/sub-app-check.yml
@@ -12,8 +12,7 @@ permissions:
 jobs:
   clippy:
     name: Clippy
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -42,8 +41,7 @@ jobs:
 
   formatting:
     name: Formatting
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -66,8 +64,7 @@ jobs:
 
   tests:
     name: Tests
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/sub-app-deploy.yml
+++ b/.github/workflows/sub-app-deploy.yml
@@ -27,8 +27,7 @@ permissions:
 jobs:
   deploy-app:
     name: Deploy App `${{ inputs.stage }}`
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.stage }}
       url: ${{ inputs.environment_url }}

--- a/.github/workflows/sub-cd.yml
+++ b/.github/workflows/sub-cd.yml
@@ -66,8 +66,7 @@ jobs:
   deployment_window:
     name: Deployment Window
     if: ${{ inputs.deploy-prod }}
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     environment:
       name: prod
       url: https://${{ vars.SUBDOMAIN_NAME }}.walletconnect.com/health

--- a/.github/workflows/sub-infra-apply.yml
+++ b/.github/workflows/sub-infra-apply.yml
@@ -25,8 +25,7 @@ permissions:
 jobs:
   apply-infra:
     name: Apply Infra `${{ inputs.stage }}`
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.stage }}
       url: ${{ inputs.stage-url }}

--- a/.github/workflows/sub-infra-check.yml
+++ b/.github/workflows/sub-infra-check.yml
@@ -17,8 +17,7 @@ permissions:
 jobs:
   check-fmt:
     name: Formatting
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -37,8 +36,7 @@ jobs:
 
   validate:
     name: Validate
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -70,8 +68,7 @@ jobs:
 
   tfsec:
     name: TFSec
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -102,8 +99,7 @@ jobs:
 
   tflint:
     name: TFLint
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/sub-infra-plan.yml
+++ b/.github/workflows/sub-infra-plan.yml
@@ -30,8 +30,7 @@ concurrency: ${{ inputs.stage }}
 jobs:
   plan:
     name: Plan `${{ inputs.stage }}`
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.stage }}
       url: ${{ inputs.stage-url }}

--- a/.github/workflows/sub-publish-image.yml
+++ b/.github/workflows/sub-publish-image.yml
@@ -20,8 +20,7 @@ permissions:
 jobs:
   build-container:
     name: Build
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/sub-validate.yml
+++ b/.github/workflows/sub-validate.yml
@@ -17,8 +17,7 @@ on:
 jobs:
   health-check:
     name: Health Check - ${{ inputs.stage }}
-    runs-on:
-      group: ${{ vars.RUN_GROUP }}
+    runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.stage }}
       url: ${{ inputs.stage-url }}

--- a/justfile
+++ b/justfile
@@ -137,16 +137,16 @@ commit-check:
     echo '==> cog not found in PATH, skipping'
   fi
 
-tf-lint: tf-validate tf-check-fmt tfsec tflint
+tf-lint: tf-validate tf-fmt tfsec tflint
 
 # Check Terraform formating
-tf-check-fmt:
+tf-fmt:
   #!/bin/bash
   set -euo pipefail
 
   if command -v terraform >/dev/null; then
     echo '==> Checking terraform fmt'
-    terraform -chdir=terraform fmt -check -recursive
+    terraform -chdir=terraform fmt -recursive
   else
     echo '==> Terraform not found in PATH, skipping'
   fi

--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -1,6 +1,5 @@
 locals {
   image          = "${var.ecr_repository_url}:${var.image_version}"
-  telemetry_port = var.port + 1
 
   desired_count = module.this.stage == "prod" ? var.autoscaling_desired_count : 1
 
@@ -83,7 +82,7 @@ resource "aws_ecs_task_definition" "app_task" {
         { "name" = "LOG_LEVEL", "value" = var.log_level },
         { "name" = "PROJECT_ID", "value" = var.project_id },
 
-        { "name" = "TELEMETRY_PROMETHEUS_PORT", "value" = tostring(local.telemetry_port) },
+        { "name" = "TELEMETRY_PROMETHEUS_PORT", "value" = tostring(local.otel_port) },
 
         { "name" = "GEOIP_DB_BUCKET", "value" = var.geoip_db_bucket_name },
         { "name" = "GEOIP_DB_KEY", "value" = var.geoip_db_key },
@@ -126,7 +125,7 @@ resource "aws_ecs_task_definition" "app_task" {
       ],
 
       environment = [
-        { name : "AWS_PROMETHEUS_SCRAPING_ENDPOINT", value : "0.0.0.0:${local.telemetry_port}" },
+        { name : "AWS_PROMETHEUS_SCRAPING_ENDPOINT", value : "0.0.0.0:${local.otel_port}" },
         { name : "AWS_PROMETHEUS_ENDPOINT", value : "${var.prometheus_endpoint}api/v1/remote_write" },
         { name = "AWS_REGION", value = module.this.region },
       ],

--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -1,5 +1,5 @@
 locals {
-  image          = "${var.ecr_repository_url}:${var.image_version}"
+  image = "${var.ecr_repository_url}:${var.image_version}"
 
   desired_count = module.this.stage == "prod" ? var.autoscaling_desired_count : 1
 

--- a/terraform/ecs/cluster.tf
+++ b/terraform/ecs/cluster.tf
@@ -95,6 +95,7 @@ resource "aws_ecs_task_definition" "app_task" {
           containerPort = var.port,
           hostPort      = var.port
         }
+        # TODO do we not need otel_port here like we do in Notify Server?
       ],
 
       logConfiguration : {

--- a/terraform/ecs/cluster_autoscaling.tf
+++ b/terraform/ecs/cluster_autoscaling.tf
@@ -1,3 +1,7 @@
+locals {
+  autoscaling_min_capacity = module.this.stage == "prod" ? var.autoscaling_min_capacity : 1
+}
+
 resource "aws_iam_role" "ecs_autoscaling_role" {
   name = "${module.this.name}-ecs-scale-application"
 
@@ -17,8 +21,8 @@ resource "aws_iam_role" "ecs_autoscaling_role" {
 }
 
 resource "aws_appautoscaling_target" "ecs_target" {
-  min_capacity       = var.min_capacity
-  max_capacity       = var.max_capacity
+  min_capacity       = local.autoscaling_min_capacity
+  max_capacity       = var.autoscaling_max_capacity
   resource_id        = "service/${aws_ecs_cluster.app_cluster.name}/${aws_ecs_service.app_service.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -21,13 +21,19 @@ variable "task_memory" {
   type        = number
 }
 
-variable "min_capacity" {
+variable "autoscaling_desired_count" {
   description = "Minimum number of instances in the autoscaling group"
   type        = number
   default     = 2
 }
 
-variable "max_capacity" {
+variable "autoscaling_min_capacity" {
+  description = "Minimum number of instances in the autoscaling group"
+  type        = number
+  default     = 2
+}
+
+variable "autoscaling_max_capacity" {
   description = "Maximum number of instances in the autoscaling group"
   type        = number
   default     = 8

--- a/terraform/res_application.tf
+++ b/terraform/res_application.tf
@@ -12,8 +12,9 @@ module "ecs" {
   image_version      = var.image_version
   task_cpu           = 512
   task_memory        = 1024
-  min_capacity       = 2
-  max_capacity       = 8
+  autoscaling_desired_count = 2
+  autoscaling_min_capacity  = 2
+  autoscaling_max_capacity  = 8
 
   # DNS
   route53_zones              = local.zones

--- a/terraform/res_application.tf
+++ b/terraform/res_application.tf
@@ -8,10 +8,10 @@ module "ecs" {
   context = module.this
 
   # Cluster
-  ecr_repository_url = local.ecr_repository_url
-  image_version      = var.image_version
-  task_cpu           = 512
-  task_memory        = 1024
+  ecr_repository_url        = local.ecr_repository_url
+  image_version             = var.image_version
+  task_cpu                  = 512
+  task_memory               = 1024
   autoscaling_desired_count = 2
   autoscaling_min_capacity  = 2
   autoscaling_max_capacity  = 8


### PR DESCRIPTION
# Description

- Fixes the math on ECS instance size calculation (copying from Notify Server), now it's actually 512.
- Downscales ECS task size and autoscaling on staging to be as minimal as possible (copying from Notify Server).
- Also downgraded Terraform Cloud config for DocumentDB size from `db.r6g.large` to `db.r5.large`
- Also uses `ubuntu-latest` runner to save costs
- Also updates `justfile` to auto-run Terraform formatting instead of just checking

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
