### PR TITLE
fix: reduce error threshold and downscale

### DIFF
--- a/terraform/monitoring/panels/docdb/available_memory.libsonnet
+++ b/terraform/monitoring/panels/docdb/available_memory.libsonnet
@@ -6,7 +6,7 @@ local targets         = grafana.targets;
 local alert           = grafana.alert;
 local alertCondition  = grafana.alertCondition;
 
-local mem_threshold = 1500000000;   // 1.5GiB
+local mem_threshold = 500000000;   // 0.5GiB
 local max_memory    = 16000000000;  // 16GiB (AWS DocDB max on db.r6g.large)
 
 local _configuration = defaults.configuration.timeseries

--- a/terraform/res_application.tf
+++ b/terraform/res_application.tf
@@ -10,8 +10,8 @@ module "ecs" {
   # Cluster
   ecr_repository_url        = local.ecr_repository_url
   image_version             = var.image_version
-  task_cpu                  = 512
-  task_memory               = 1024
+  task_cpu                  = 256
+  task_memory               = 512
   autoscaling_desired_count = 2
   autoscaling_min_capacity  = 2
   autoscaling_max_capacity  = 8


### PR DESCRIPTION
# Description

Since DocumentDB was downscaled, it violated the alarm. Adjusting alarm to fix. [Slack conversation](https://walletconnect.slack.com/archives/C058RS0MH38/p1710824505648449?thread_ts=1710824416.779259&cid=C058RS0MH38)

Also downscale ECS to minimum scale.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
