### PR TITLE
chore: replace WalletConnect/actions-rs with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/sub-app-check.yml
+++ b/.github/workflows/sub-app-check.yml
@@ -18,12 +18,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: "Install Rust ${{ inputs.version }}"
-        uses: WalletConnect/actions-rs/toolchain@1.0.0
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ vars.RUST_VERSION }}
-          profile: 'minimal'
-          components: 'cargo,clippy'
-          override: true
+          components: clippy
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
@@ -34,10 +32,7 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.3
 
       - name: "Clippy"
-        uses: WalletConnect/actions-rs/cargo@1.0.0
-        with:
-          command: clippy
-          args: -- -D warnings
+        run: cargo clippy -- -D warnings
 
   formatting:
     name: Formatting
@@ -47,20 +42,16 @@ jobs:
         uses: actions/checkout@v3
 
       - name: "Install Rust ${{ inputs.version }}"
-        uses: WalletConnect/actions-rs/toolchain@1.0.0
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ vars.RUST_VERSION }}
-          profile: 'default'
-          override: true
+          components: rustfmt
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
 
       - name: "Check Formatting"
-        uses: WalletConnect/actions-rs/cargo@1.0.0
-        with:
-          command: fmt
-          args: -- --check
+        run: cargo fmt -- --check
 
   tests:
     name: Tests
@@ -70,11 +61,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: "Install Rust ${{ inputs.version }}"
-        uses: WalletConnect/actions-rs/toolchain@1.0.0
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ vars.RUST_VERSION }}
-          profile: 'default'
-          override: true
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
@@ -85,7 +74,4 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.3
 
       - name: "Unit Tests"
-        uses: WalletConnect/actions-rs/cargo@1.0.0
-        with:
-          command: test
-          args: --all-features
+        run: cargo test --all-features


### PR DESCRIPTION
## Summary
- Replace deprecated `WalletConnect/actions-rs` with `dtolnay/rust-toolchain` for Rust toolchain setup in CI
- Simplifies workflow configuration and reduces lines of code

## Test plan
- [ ] Verify CI workflow runs successfully with the new action
- [ ] Confirm Rust toolchain is properly installed and configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)